### PR TITLE
Add Sudo and Sync Async

### DIFF
--- a/src/Extension.ts
+++ b/src/Extension.ts
@@ -20,4 +20,3 @@ export interface Extension {
   permissions: Permissions;
   source: ExtensionSource;
 }
-

--- a/src/Permissions.ts
+++ b/src/Permissions.ts
@@ -35,9 +35,12 @@ export type SignPermission =
   };
 
 export type Permissions = {
+  sudo?: boolean, // Allows everything
   storage?: '*'; // Ext. is allowed to read and write from local storage
   trx?: '*' | TrxPermission[] // Ext. is allowed to call these functions
   sign?: '*' | SignPermission[] // Ext. is allowed to sign these messages
+  popups?: boolean // Ext. is allowed to open pop-ups
+  modals?: boolean // Ext. is allowed to use alert modals
 };
 
 function strEq(a: string, b: string): boolean {
@@ -220,6 +223,10 @@ function checkSignTypedData(params: any[], { sign }: Permissions, operator: stri
 }
 
 export function checkPermission(message: InMessage, permissions: Permissions, operator: string | null): null | string {
+  if (permissions.sudo === true) {
+    return null;
+  }
+
   switch (message.type) {
     case 'storage:read':
       if (permissions.storage && permissions.storage) {

--- a/src/RPC.ts
+++ b/src/RPC.ts
@@ -53,7 +53,9 @@ export function buildRPC(): RPC {
       reject = reject_;
     });
     handlers[msgId] = { resolve: resolve!, reject: reject! };
-    window.top?.postMessage( { msgId: msgId, message: inMsg }, "*");
+    if (window.top && window.self !== window.top) {
+      window.top.postMessage( { msgId: msgId, message: inMsg }, "*");
+    }
     return p as unknown as any;
   }
 

--- a/src/RPCWeb3Provider.ts
+++ b/src/RPCWeb3Provider.ts
@@ -1,6 +1,23 @@
 import { sendWeb3, SendRPC } from './RPC';
 import { JsonRpcProvider } from '@ethersproject/providers';
 
+interface JsonRpcRequest {
+  id: string | undefined;
+  jsonrpc: '2.0';
+  method: string;
+  params?: Array<any>;
+}
+
+interface JsonRpcResponse {
+  id: string | undefined;
+  jsonrpc: '2.0';
+  method: string;
+  result?: unknown;
+  error?: Error;
+}
+
+type JsonRpcCallback = (error: Error | undefined, response: JsonRpcResponse) => unknown;
+
 export class RPCWeb3Provider extends JsonRpcProvider  {
   sendRPC: SendRPC;
 
@@ -22,5 +39,26 @@ export class RPCWeb3Provider extends JsonRpcProvider  {
       }, 0);
     }
     return res;
+  }
+
+  async sendAsync(payload: JsonRpcRequest, callback: JsonRpcCallback): Promise<void> {
+    const {id, method, params} = payload;
+    let res;
+    try {
+      let result = await this.send(method, params || []);
+      callback(undefined, {
+        id,
+        jsonrpc: '2.0',
+        method,
+        result,
+      });
+    } catch (error: unknown) {
+      callback(error as Error, {
+        id,
+        jsonrpc: '2.0',
+        method,
+        error: error as Error
+      });
+    }
   }
 }

--- a/tests/Permissions.test.ts
+++ b/tests/Permissions.test.ts
@@ -102,6 +102,13 @@ const typedDataV4 = {
 const typedParams = [FROM, typedDataV4];
 
 let tests: Test[] = [
+  /** SUDO **/
+  {
+    name: 'sudo',
+    permissions: { sudo: true },
+    message: { type: 'storage:read', key: 'dog' },
+    exp: null
+  },
   /** STORAGE **/
   {
     name: 'storage:read - empty',


### PR DESCRIPTION
This patch adds a few extra perms, including "sudo" that is meant to grant all permissions, which can be used, for instance, in testing and developing extensions. We also implement `provider.sendAsync`, which is the out-dated way of sending messages through a provider, but apparently is used by some older extensions.

We also add some permissions for `modals` and `popups`, which simply add extra sandbox attributes to iframes to allow opening new windows and/or creating "alerts".