### PR TITLE
Use Extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@compound-finance/comet-extension",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Extension.ts
+++ b/src/Extension.ts
@@ -1,4 +1,4 @@
-import { Permissions } from './Permissions';
+import { Permissions } from './Permissions.js';
 
 /**
  * Extensions

--- a/src/Extensions.ts
+++ b/src/Extensions.ts
@@ -1,4 +1,4 @@
-import { Extension } from './Extension';
+import { Extension } from './Extension.js';
 
 export const extensions: Extension[] = [
   {

--- a/src/LocalStorage.ts
+++ b/src/LocalStorage.ts
@@ -1,4 +1,4 @@
-import { storageRead, storageWrite, SendRPC } from './RPC';
+import { storageRead, storageWrite, SendRPC } from './RPC.js';
 
 export class LocalStorage {
   sendRPC?: SendRPC;

--- a/src/MessageTypes.ts
+++ b/src/MessageTypes.ts
@@ -1,5 +1,5 @@
 import { TransactionResponse } from '@ethersproject/providers';
-import type { CometState } from './CometState';
+import type { CometState } from './CometState.js';
 
 /**
  * Extensions - Messages

--- a/src/Permissions.ts
+++ b/src/Permissions.ts
@@ -1,5 +1,5 @@
-import { InMessage } from './MessageTypes';
 import { Interface } from '@ethersproject/abi';
+import { InMessage } from './MessageTypes.js';
 
 /**
  * Extensions - Permissions

--- a/src/RPC.ts
+++ b/src/RPC.ts
@@ -1,5 +1,5 @@
-import { ExtMessage, ExtMessageHandler, InMessage, OutMessage } from './MessageTypes';
 import { TransactionResponse } from '@ethersproject/providers';
+import { ExtMessage, ExtMessageHandler, InMessage, OutMessage } from './MessageTypes.js';
 
 export interface RPC {
   on: (handler: ExtMessageHandler) => void;

--- a/src/RPCWeb3Provider.ts
+++ b/src/RPCWeb3Provider.ts
@@ -1,5 +1,5 @@
-import { sendWeb3, SendRPC } from './RPC';
 import { JsonRpcProvider } from '@ethersproject/providers';
+import { sendWeb3, SendRPC } from './RPC.js';
 
 interface JsonRpcRequest {
   id: string | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,14 @@
-export type { InMessage, OutMessage, ExtMessage, ExtMessageHandler } from './MessageTypes';
+export type { InMessage, OutMessage, ExtMessage, ExtMessageHandler } from './MessageTypes.js';
 
-export type { RPC, SendRPC } from './RPC';
-export { buildRPC, storageRead, storageWrite, sendWeb3 } from './RPC';
+export type { RPC, SendRPC } from './RPC.js';
+export { buildRPC, storageRead, storageWrite, sendWeb3 } from './RPC.js';
 
-export { RPCWeb3Provider } from './RPCWeb3Provider';
+export { RPCWeb3Provider } from './RPCWeb3Provider.js';
 
-export type { Extension } from './Extension';
-export { extensions } from './Extensions';
+export type { Extension } from './Extension.js';
+export { extensions } from './Extensions.js';
 
-export type { Permissions } from './Permissions';
-export { checkPermission } from './Permissions';
+export type { Permissions } from './Permissions.js';
+export { checkPermission } from './Permissions.js';
 
-export type { CometState } from './CometState';
+export type { CometState } from './CometState.js';

--- a/tests/Permissions.test.ts
+++ b/tests/Permissions.test.ts
@@ -1,8 +1,8 @@
 import test from 'ava';
 import { parseEther } from '@ethersproject/units';
 import { Interface } from '@ethersproject/abi';
-import { InMessage } from '../src/MessageTypes';
-import { Permissions, checkPermission } from '../src/Permissions';
+import { InMessage } from '../src/MessageTypes.js';
+import { Permissions, checkPermission } from '../src/Permissions.js';
 
 interface Test {
   name: string;


### PR DESCRIPTION
This patch uses Extensions, so that the output has `import { X } from './X.js'` instead of `import { X } from './X'`, which is required if we're going to distribute this package as a type: module.