### PR TITLE
add compound v2 info extension

### DIFF
--- a/src/Extensions.ts
+++ b/src/Extensions.ts
@@ -55,5 +55,22 @@ export const extensions: Extension[] = [
     supportedMarkets: {
       '1_USDC_0xc3d688B66703497DAA19211EEdff47f25384cdc3': null
     }
+  },
+  {
+    id: 'compound_V2_info',
+    name: 'Compound V2 Info',
+    description: 'Data and analytics for Compound V2',
+    developer: 'Paperclip Labs',
+    links: {
+      github: 'https://github.com/papercliplabs/compound-info',
+      website: 'https://paperclip.xyz'
+    },
+    permissions: {},
+    source: {
+      ipfs: 'QmdoThSUCuHDGinSvhNuvnihvWWdriwsNzCnYUjGrei1o5',
+      domain: 'compound-info-v2.infura-ipfs.io',
+      path: '?embedded'
+    },
+    supportedMarkets: {}
   }
 ];


### PR DESCRIPTION
Adding Compound V2 Info extension.

Original website: https://compoundfinance.info
IPFS deployment, embedded version: https://compound-info-v2.infura-ipfs.io/ipfs/QmdoThSUCuHDGinSvhNuvnihvWWdriwsNzCnYUjGrei1o5/?embedded