### PR TITLE
doc: update README extensions manifest update patch example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,25 +79,46 @@ Once you've created an extension, you may create a pull request to this repo to 
 
 :warning: This repo contains a list of Extensions curated by Compound. See [Curation and Safety](#) below for more information. Extensions may also be used in stand-alone mode (see the [Creating an Extension](#Creating-an-Extension)) or may be integrated into a public fork of the Compound III interface.
 
-To add an extension, create a pull request to this repo, adding the configuration for your extension to `src/extensions.json`. For example:
+To add an extension, create a pull request to this repo, adding the configuration for your extension to `src/Extensions.ts`. For example:
 
 ```diff
- [
+ export const extensions: Extension[] = [
    ...,
 +  {
-+    "id": "comet_migrator",
-+    "name": "Compound III Migrator",
-+    "permissions": {
-+      "read": "*",
-+      "write": "*"
++    id: 'comet_migrator',
++    name: 'Compound V3 Position Migrator',
++    description: 'Migrate USDC balances and supported collateral assets from Compound V2 to the Compound V3 USDC market on the Ethereum network.',
++    developer: 'Compound Labs',
++    links: {
++      github: 'https://github.com/compound-finance/comet-migrator',
++      website: 'https://compound.finance/'
 +    },
-+    "source": {
-+      "ipfs": "QmRe6VBCXE9Wwb5fKkynYxtqbZ6Af1i72mhRzyN95vhxMy",
-+      "domain": "comet-v2-migrator.infura-ipfs.io",
-+      "path": "/embedded.html"
++    permissions: {
++      storage: '*',
++      trx: [
++        {
++          contract: '$operator',
++          abi: 'migrate((address,uint256)[],uint256)',
++          params: '*'
++        },
++        {
++          contract: '*',
++          abi: 'approve(address,uint256)',
++          params: ['$operator', '*']
++        }
++      ]
++    },
++    source: {
++      ipfs: 'QmeDbWFcgZkDvuMFoQQezyAd69LwvPv5mgwVBDw7bfTrsB',
++      domain: 'comet-v2-migrator.infura-ipfs.io',
++      path: '/embedded.html'
++    },
++    supportedMarkets: {
++      '1_USDC_0xc3d688B66703497DAA19211EEdff47f25384cdc3': '0x1dD398C2c7fAee61eBB522c434e9f83cf3A9196b',
++      '5_USDC_0x3EE77595A8459e93C2888b13aDB354017B198188': '0x6d1f37f5c2c6cf70871a93e439bf921c195c427f'
 +    }
-+  }
-]
++  },
+];
 ```
 
 See [src/Extension.ts](./blob/main/src/Extension.ts) for more details on format of the extension configuration.


### PR DESCRIPTION
The README directions looked a little out of date, so I updated them to correspond with the current `Extensions.ts` manifest.